### PR TITLE
Detect all results in SpirocheteDetector

### DIFF
--- a/app/src/main/java/local/no10/spriocount/SpirocheteDetector.java
+++ b/app/src/main/java/local/no10/spriocount/SpirocheteDetector.java
@@ -13,21 +13,14 @@ import java.util.List;
 
 public class SpirocheteDetector {
 
-    private static final int DEFAULT_MAX_RESULTS = 50;
     public static final float DEFAULT_THRESHOLD = 0.3f;
 
-    private int maxResults;
     private float threshold;
     private final Context context;
 
     SpirocheteDetector(Context context) {
         this.context = context;
-        this.maxResults = DEFAULT_MAX_RESULTS;
         this.threshold = DEFAULT_THRESHOLD;
-    }
-
-    public void setMaxResults(int maxResults) {
-        this.maxResults = maxResults;
     }
 
     public void setThreshold(float threshold) {
@@ -43,7 +36,6 @@ public class SpirocheteDetector {
     public List<RectF> runObjectDetection(SpirocountImage scimage) {
         TensorImage image = scimage.tensorImage();
         ObjectDetector.ObjectDetectorOptions options = ObjectDetector.ObjectDetectorOptions.builder()
-                .setMaxResults(maxResults)
                 .setScoreThreshold(threshold)
                 .build();
 


### PR DESCRIPTION
Remove the setting for the maximum number of objects to detect, and
use the default behavior, which is to detect all recognized objects.
The maximum number will now be determined by the model itself.

Closes #1