### PR TITLE
Explicitly remove old captured images

### DIFF
--- a/app/src/main/java/com/spirocount/spriocount/TempFileManager.java
+++ b/app/src/main/java/com/spirocount/spriocount/TempFileManager.java
@@ -1,0 +1,49 @@
+package com.spirocount.spriocount;
+
+import android.net.Uri;
+
+import java.io.File;
+
+/**
+ * Holds a single file descriptor and associated uri.
+ */
+public class TempFileManager {
+    private File file;
+    private Uri uri;
+
+    public TempFileManager() {
+        file = null;
+        uri = null;
+    }
+
+    public boolean empty() {
+        return file == null;
+    }
+
+    public Uri getTempFileUri() {
+        return uri;
+    }
+
+    /**
+     * Ensuring that the file and uri are related is the responsibility of the caller. Neither should
+     * be null.
+     */
+    public void storeTempFile(File file, Uri uri) {
+        if (!empty()) {
+            deleteTempFile();
+        }
+        this.file = file;
+        this.uri = uri;
+    }
+
+    public void deleteTempFile() {
+        if (empty()) {
+            return;
+        }
+        boolean success = file.delete();
+        if (success) {
+            file = null;
+            uri = null;
+        }
+    }
+}

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <external-files-path
-        name="spirocount_images"
-        path="Pictures" />
+<paths>
+    <cache-path
+        name="cache"
+        path="." />
 </paths>


### PR DESCRIPTION
Introduces a manager class to ensure old files are deleted when no longer needed. It also moves image storage to the app cache rather than the app specific Picture storage area.